### PR TITLE
Add PV for mysql & optimise docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM golang:latest
+FROM golang:alpine3.18 AS builder
 
-WORKDIR /app
+RUN apk --no-cache add ca-certificates git
+WORKDIR /build
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY pkg ./pkg
 COPY cli ./cli
-COPY go.mod ./
-RUN go mod tidy -e
+RUN cd cli \
+    && CGO_ENABLED=0 go build -o musicbinary
 
-RUN cd cli && go build -o musicbinary
+FROM alpine:latest AS final
+RUN apk --no-cache upgrade
+RUN mkdir /app \
+    && adduser -D music --shell /usr/sbin/nologin \
+    && chown -R music:music /app
+WORKDIR /app
+COPY --from=builder --chown=music:music /build/cli/musicbinary .
+USER music
 
-CMD ["/app/cli/musicbinary"]
+CMD ["/app/musicbinary"]

--- a/manifests/mysql/pv-mysql.yaml
+++ b/manifests/mysql/pv-mysql.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-pv-claim
-  namespace: db-ns
+  name: mysql-pv
 spec:
   storageClassName: hostpath
   accessModes:
     - ReadWriteOnce
-  volumeName: mysql-pv
   resources:
     requests:
       storage: 20Gi
+  hostPath:
+    path: "/opt/data/mysql"

--- a/manifests/mysql/pv-mysql.yaml
+++ b/manifests/mysql/pv-mysql.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: PersistentVolumeClaim
+kind: PersistentVolume
 metadata:
   name: mysql-pv
 spec:


### PR DESCRIPTION
## Changes proposed:

- add a pv manifest with a hostpath specified
- add `volumeName` field spec to PVC manifest(so that it can easily bind with the PV)
- optimise the docker image build (smaller built image size)